### PR TITLE
chore(ci): optional auto-deploy to Render via hook

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,13 @@
+name: Render Deploy
+on:
+  push:
+    branches: [ "main" ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.RENDER_DEPLOY_HOOK_URL != '' }}
+    steps:
+      - name: Trigger Render deploy hook
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "${{ secrets.RENDER_DEPLOY_HOOK_URL }}" -H "Accept: application/json"


### PR DESCRIPTION
Adds optional GitHub Actions workflow for automatic Render deployment.

## Changes
- Created 
- Triggers on push to main branch
- Only runs if  secret exists
- Uses secure curl POST to trigger Render deployment
- Gracefully does nothing if secret is not configured

## Usage
To enable automatic deployments:
1. Go to repository Settings → Secrets and variables → Actions
2. Add new repository secret: 
3. Set value to your Render service's deploy hook URL
4. Future pushes to main will automatically trigger Render deployments

## Benefits
- Optional auto-deployment (only if secret configured)
- No impact if secret is absent
- Secure webhook integration with Render
- Eliminates need for manual deployments