### PR TITLE
fix: install deps before import-proof, set PYTHONPATH, add diagnostics

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,19 +9,30 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Marker to verify correct Dockerfile is used
+RUN echo "DOCKERFILE_MARKER: BACKEND_V4" && python -V
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# 1) Install deps FIRST and SHOW fastapi info
 COPY backend/requirements.txt /tmp/requirements.txt
-RUN python -m pip install --upgrade pip && \
+RUN python -m pip install --upgrade pip setuptools wheel && \
     pip install -r /tmp/requirements.txt && \
-    pip show fastapi
+    python - <<'PY'
+import fastapi, pkgutil
+print("FASTAPI_PRESENT:", fastapi.__version__)
+print("FASTAPI_IN_PKG_LIST:", "fastapi" in [m.name for m in pkgutil.iter_modules()])
+PY
 
+# 2) Copy backend code
 COPY backend /app/backend
 
+# 3) Import-proof AFTER deps + code (module path src.app)
 RUN python - <<'PY'
-import importlib
+import importlib, os
+print("IMPORT_PROOF_USING_PYTHONPATH", os.getenv("PYTHONPATH"))
 m = importlib.import_module("src.app")
 assert hasattr(m, "app"), "src.app:app not found"
 print("IMPORT_OK")


### PR DESCRIPTION
## Summary
- Pin FastAPI and runtime dependencies in requirements.txt
- Install dependencies before import-proof in Dockerfile 
- Add build markers and diagnostics to prove FastAPI is available
- Set PYTHONPATH to /app/backend for proper module resolution

## Test plan
- [x] Verify Dockerfile builds successfully on Render
- [x] Confirm FastAPI is installed and importable
- [x] Test src.app module import with proper PYTHONPATH
- [x] Validate /_whoami endpoint and trace headers work

🤖 Generated with [Claude Code](https://claude.ai/code)