### PR TITLE
fix(deps): add missing asyncpg for database connectivity

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ pydantic==2.9.2
 prometheus-client==0.21.0
 structlog==24.4.0
 psycopg[binary]==3.2.3
+asyncpg==0.29.0
 redis==5.0.8
 python-dotenv==1.0.1
 tenacity==9.0.0


### PR DESCRIPTION
## Summary
- Add `asyncpg==0.29.0` to requirements.txt
- Fixes `ModuleNotFoundError: No module named 'asyncpg'` in app.py line 95
- Required for database health checks and connection pooling

## Root Cause
The app.py imports asyncpg for database connectivity but it wasn't in requirements.txt.

## Test Plan
- [x] Verify Docker build completes without asyncpg import errors
- [x] Confirm src.app module imports successfully
- [x] Database health check endpoints should work

🤖 Generated with [Claude Code](https://claude.ai/code)