### PR TITLE
feat(api): /discovery/explain + /discovery/test

### DIFF
--- a/backend/src/routes/discovery.py
+++ b/backend/src/routes/discovery.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from typing import List, Dict
 import json
 from backend.src.shared.redis_client import get_redis_client
@@ -52,3 +52,27 @@ async def get_discovery_status() -> Dict:
             return {"count": 0, "ts": None}
     except Exception:
         return {"count": 0, "ts": None}
+
+@router.get("/explain")
+async def discovery_explain():
+    try:
+        redis_client = get_redis_client()
+        raw = redis_client.get("amc:discovery:explain.latest")
+        if not raw:
+            return {"ts": None, "count": 0, "trace": {"stages":[], "counts_in":{}, "counts_out":{}, "rejections":{}, "samples":{}}}
+        return json.loads(raw)
+    except Exception:
+        return {"ts": None, "count": 0, "trace": {"stages":[], "counts_in":{}, "counts_out":{}, "rejections":{}, "samples":{}}}
+
+@router.get("/test")
+async def discovery_test(relaxed: bool = Query(True), limit: int = Query(10)):
+    try:
+        try:
+            from backend.src.jobs.discover import select_candidates
+            items, trace = await select_candidates(relaxed=relaxed, limit=limit, with_trace=True)
+            return {"items": items, "trace": trace, "relaxed": relaxed, "limit": limit}
+        except ImportError:
+            # Fallback if select_candidates doesn't exist yet
+            return {"items": [], "trace": {"error": "select_candidates function not implemented yet"}, "relaxed": relaxed, "limit": limit}
+    except Exception as e:
+        return {"items": [], "trace": {}, "error": str(e), "relaxed": relaxed, "limit": limit}


### PR DESCRIPTION
## Summary
- Add `/discovery/explain` endpoint to expose Redis-cached discovery trace
- Add `/discovery/test` endpoint for live discovery testing with parameters
- Enables inspection of production discovery runs and debugging

## Implementation Details

**`GET /discovery/explain`:**
- Reads `amc:discovery:explain.latest` from Redis
- Returns detailed trace with stages, counts, rejections, and samples
- Provides default empty structure when no trace available
- Format: `{ts, count, trace: {stages, counts_in, counts_out, rejections, samples}}`

**`GET /discovery/test?relaxed=true&limit=10`:**
- Calls `select_candidates()` function with trace enabled 
- Query parameters: `relaxed` (boolean), `limit` (int)
- Returns: `{items, trace, relaxed, limit, error?}`
- Graceful fallback if `select_candidates` not implemented yet

## Use Cases
1. **Production Debugging:** View traces from scheduled discovery runs
2. **Parameter Testing:** Test discovery logic with different relaxed/limit values
3. **Performance Analysis:** Examine stage-by-stage filtering and rejection reasons
4. **Data Quality:** Inspect sample data at each pipeline stage

## Redis Keys
- `amc:discovery:explain.latest` - Latest discovery execution trace
- Complements existing `amc:discovery:contenders.latest` and `amc:discovery:status`

🤖 Generated with [Claude Code](https://claude.ai/code)