### PR TITLE
fix(api): compat alias for `app.*` → `src.*` to stop cron/uvicorn import errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,13 +31,18 @@ PY
 # 2) Copy backend code
 COPY backend /app/backend
 
-# 3) Import-proof AFTER deps + code (module path src.app)
+# 3) Import-proof AFTER deps + code (both src.app and app.main entrypoints)
 RUN python - <<'PY'
 import importlib, os
 print("IMPORT_PROOF_USING_PYTHONPATH", os.getenv("PYTHONPATH"))
+# Test original src.app entrypoint
 m = importlib.import_module("src.app")
 assert hasattr(m, "app"), "src.app:app not found"
 print("IMPORT_OK")
+# Test new app.main compatibility entrypoint
+app_main = importlib.import_module("app.main")
+assert hasattr(app_main, "app"), "app.main:app not found"
+print("IMPORT_OK_ALIAS")
 PY
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- Add backward-compatible import aliases for `app.*` → `src.*` module paths
- Fixes cron job and uvicorn import errors from old entrypoints
- No behavior changes - pure import compatibility layer

## Implementation Details

**New Compatibility Files:**
- `backend/app/__init__.py` - Maps `app` package to `src` using `sys.modules`
- `backend/app/main.py` - Exposes `app` for `uvicorn app.main:app` entrypoint
- `backend/app/routes/__init__.py` - Re-exports all `src.routes` for `from app.routes import X`

**Import Aliasing Logic:**
```python
_src = importlib.import_module("src")
sys.modules.setdefault("app", _src)
sys.modules.setdefault("app.main", importlib.import_module("src.app"))
sys.modules.setdefault("app.routes", importlib.import_module("src.routes"))
```

**Dockerfile Updates:**
- Extended import-proof to verify both `src.app` and `app.main` entrypoints
- Ensures deployment won't break with either import path

## Backward Compatibility Support
These patterns now work seamlessly:
- ✅ `uvicorn app.main:app` (legacy uvicorn command)
- ✅ `from app.routes import trades` (legacy imports) 
- ✅ `uvicorn src.app:app` (current command)
- ✅ `from src.routes import trades` (current imports)

## Use Cases
1. **Cron Jobs:** Legacy scripts using `app.*` imports won't break
2. **Uvicorn Commands:** Both old and new entrypoints work
3. **External Scripts:** Third-party code expecting `app` module structure
4. **Migration Safety:** Gradual migration from old to new import paths

## Testing
- Docker build verifies both entrypoints during image creation
- No runtime performance impact - aliases resolved at import time
- Maintains existing `src.*` as primary structure

🤖 Generated with [Claude Code](https://claude.ai/code)