### PR TITLE
fix(api): resilient import of select_candidates from jobs.{discover|discovery} and build-time proof

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -45,5 +45,22 @@ assert hasattr(app_main, "app"), "app.main:app not found"
 print("IMPORT_OK_ALIAS")
 PY
 
+# 4) Prove select_candidates is available at build time
+RUN python - <<'PY'
+import importlib, sys
+mods = ("backend.src.jobs.discovery","backend.src.jobs.discover")
+found = []
+for mod in mods:
+    try:
+        m = importlib.import_module(mod)
+        f = getattr(m, "select_candidates", None)
+        if callable(f):
+            found.append(mod)
+    except Exception:
+        pass
+assert found, "No select_candidates in jobs.discovery or jobs.discover"
+print("SELECTOR_OK:", ",".join(found))
+PY
+
 EXPOSE 8000
 CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/src/routes/discovery.py
+++ b/backend/src/routes/discovery.py
@@ -1,9 +1,22 @@
 from fastapi import APIRouter, Query
 from typing import List, Dict
 import json
+import importlib
 from backend.src.shared.redis_client import get_redis_client
 
 router = APIRouter()
+
+def _load_selector():
+    """Load select_candidates function from available jobs modules"""
+    for mod in ("backend.src.jobs.discovery", "backend.src.jobs.discover"):
+        try:
+            m = importlib.import_module(mod)
+            f = getattr(m, "select_candidates", None)
+            if callable(f):
+                return f, mod
+        except Exception:
+            continue
+    return None, None
 
 @router.get("/contenders")
 async def get_contenders() -> List[Dict]:
@@ -66,13 +79,15 @@ async def discovery_explain():
 
 @router.get("/test")
 async def discovery_test(relaxed: bool = Query(True), limit: int = Query(10)):
+    f, mod = _load_selector()
+    if not f:
+        return {"items": [], "trace": {}, "error": "select_candidates not found in jobs.discovery or jobs.discover"}
     try:
-        try:
-            from backend.src.jobs.discover import select_candidates
-            items, trace = await select_candidates(relaxed=relaxed, limit=limit, with_trace=True)
-            return {"items": items, "trace": trace, "relaxed": relaxed, "limit": limit}
-        except ImportError:
-            # Fallback if select_candidates doesn't exist yet
-            return {"items": [], "trace": {"error": "select_candidates function not implemented yet"}, "relaxed": relaxed, "limit": limit}
+        res = await f(relaxed=relaxed, limit=limit, with_trace=True)  # type: ignore
+        if isinstance(res, tuple) and len(res) == 2:
+            items, trace = res
+        else:
+            items, trace = res, {}
+        return {"items": items, "trace": trace, "module": mod, "relaxed": relaxed, "limit": limit}
     except Exception as e:
-        return {"items": [], "trace": {}, "error": str(e), "relaxed": relaxed, "limit": limit}
+        return {"items": [], "trace": {}, "module": mod, "error": str(e)}


### PR DESCRIPTION
## Summary
- Make API resilient to either `jobs.discover` or `jobs.discovery` module names
- Add build-time proof that `select_candidates` function is available
- Prevent runtime import errors when job module names change

## Implementation Details

**Resilient Import Helper (`_load_selector()`):**
- Tries both `backend.src.jobs.discovery` and `backend.src.jobs.discover`
- Returns first callable `select_candidates` function found
- Graceful fallback when neither module exists

**Updated `/discovery/test` Endpoint:**
- Uses dynamic import instead of static import
- Returns module name in response for debugging
- Handles both tuple and single return value formats
- Better error reporting with module context

**Dockerfile Build-Time Proof:**
- Verifies `select_candidates` is callable before image completion
- Tests both possible module locations
- Fails build if function unavailable (fail-fast principle)
- Shows `SELECTOR_OK: <module_name>` in build logs

## Benefits
1. **Resilience:** Works regardless of job module naming convention
2. **Early Detection:** Build fails if selector function missing
3. **Better Debugging:** Shows which module provides the function
4. **Future-Proof:** Handles module refactoring without API changes

## Build Verification
The Docker build will now show:
```
SELECTOR_OK: backend.src.jobs.discover
```

This proves the function is available before the image is complete.

🤖 Generated with [Claude Code](https://claude.ai/code)