### PR TITLE
fix(api): load selector from src.jobs.{discovery|discover} and fix Dockerfile proof

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -47,8 +47,8 @@ PY
 
 # 4) Prove select_candidates is available at build time
 RUN python - <<'PY'
-import importlib, sys
-mods = ("backend.src.jobs.discovery","backend.src.jobs.discover")
+import importlib
+mods = ("src.jobs.discovery","src.jobs.discover")
 found = []
 for mod in mods:
     try:
@@ -58,7 +58,7 @@ for mod in mods:
             found.append(mod)
     except Exception:
         pass
-assert found, "No select_candidates in jobs.discovery or jobs.discover"
+assert found, "No select_candidates in src.jobs.discovery or src.jobs.discover"
 print("SELECTOR_OK:", ",".join(found))
 PY
 

--- a/backend/src/routes/discovery.py
+++ b/backend/src/routes/discovery.py
@@ -8,7 +8,7 @@ router = APIRouter()
 
 def _load_selector():
     """Load select_candidates function from available jobs modules"""
-    for mod in ("backend.src.jobs.discovery", "backend.src.jobs.discover"):
+    for mod in ("src.jobs.discovery", "src.jobs.discover"):
         try:
             m = importlib.import_module(mod)
             f = getattr(m, "select_candidates", None)
@@ -81,7 +81,7 @@ async def discovery_explain():
 async def discovery_test(relaxed: bool = Query(True), limit: int = Query(10)):
     f, mod = _load_selector()
     if not f:
-        return {"items": [], "trace": {}, "error": "select_candidates not found in jobs.discovery or jobs.discover"}
+        return {"items": [], "trace": {}, "error": "select_candidates not found in src.jobs.discovery or src.jobs.discover"}
     try:
         res = await f(relaxed=relaxed, limit=limit, with_trace=True)  # type: ignore
         if isinstance(res, tuple) and len(res) == 2:


### PR DESCRIPTION
## Summary
- Stop using `backend.src.*` import paths, use clean `src.*` paths instead
- Fix both runtime API and build-time Dockerfile proof to use consistent import structure
- Maintain PYTHONPATH=/app/backend for proper module resolution

## Implementation Details

**Updated `_load_selector()` in discovery.py:**
- Changed from `backend.src.jobs.discovery` → `src.jobs.discovery`
- Changed from `backend.src.jobs.discover` → `src.jobs.discover`
- Updated error message to reflect new paths

**Fixed Dockerfile Proof:**
- Updated module list to `("src.jobs.discovery","src.jobs.discover")`
- Updated assertion message for consistency
- Still shows `SELECTOR_OK: src.jobs.discover` in build logs

**Import Path Consistency:**
- Runtime API: `src.jobs.*`
- Build proof: `src.jobs.*`
- PYTHONPATH: `/app/backend` (unchanged - enables src.* resolution)
- Main app proof: `src.app` (unchanged)

## Benefits
1. **Clean Imports:** Removes redundant `backend.` prefix from import paths
2. **Consistency:** Same import structure used in API and build proof
3. **Maintainability:** Simpler, shorter import paths
4. **Standards:** Follows Python package import conventions

## Verification
Docker build will show:
- `IMPORT_OK` (src.app proof)
- `IMPORT_OK_ALIAS` (app.main compatibility)
- `SELECTOR_OK: src.jobs.discover` (selector proof)

🤖 Generated with [Claude Code](https://claude.ai/code)