### PR TITLE
fix(api): robust app→backend.src alias; proof tries src.* and backend.src.*

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,22 +31,22 @@ PY
 # 2) Copy backend code
 COPY backend /app/backend
 
-# ---- import proofs (warn-only) ----
 RUN python - <<'PY'
 import importlib
-mods = ("src.app","app.main","src.jobs.discover","src.jobs.discovery")
-ok, fail = [], []
+mods = (
+    "backend.src.app","app.main","backend.src.jobs.discover","backend.src.jobs.discovery",
+    "src.app","src.jobs.discover","src.jobs.discovery"
+)
+ok, warn = [], []
 for m in mods:
     try:
-        importlib.import_module(m)
-        ok.append(m)
+        importlib.import_module(m); ok.append(m)
     except Exception as e:
-        fail.append((m, repr(e)))
+        warn.append((m, repr(e)))
 print("PROOF_OK:", ",".join(ok))
-for m,e in fail:
+for m,e in warn:
     print("PROOF_WARN:", m, e)
 PY
-# -----------------------------------
 
 EXPOSE 8000
 CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,14 +1,16 @@
-# backend/app/__init__.py
 import importlib, sys, os
 from pathlib import Path
-_here = Path(__file__).resolve()
-_backend_root = _here.parent.parent  # …/backend
-if str(_backend_root) not in sys.path:
-    sys.path.insert(0, str(_backend_root))
-_src = importlib.import_module("src")
-sys.modules.setdefault("app", _src)
-sys.modules.setdefault("app.main", importlib.import_module("src.app"))
+
+# Ensure /app is on sys.path (Render working dir); backend folder is under it
+root = Path(__file__).resolve().parents[2]   # …/backend/../
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+# Prefer backend.src.* (always present in this repo)
+_backend_src = importlib.import_module("backend.src")
+sys.modules.setdefault("app", _backend_src)
+sys.modules.setdefault("app.main", importlib.import_module("backend.src.app"))
 try:
-    sys.modules.setdefault("app.routes", importlib.import_module("src.routes"))
+    sys.modules.setdefault("app.routes", importlib.import_module("backend.src.routes"))
 except Exception:
     pass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,2 +1,1 @@
-# backend/app/main.py
-from src.app import app
+from backend.src.app import app

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,3 +1,1 @@
-# backend/app/routes/__init__.py
-# Re-export routers so `from app.routes import X` works
-from src.routes import *  # noqa
+from backend.src.routes import *  # re-export


### PR DESCRIPTION
## Summary
- Updates app.* import aliases to resolve to backend.src.* instead of src.* for better compatibility without PYTHONPATH dependencies
- Docker proof now tests both src.* and backend.src.* import patterns
- Maintains backward compatibility while improving robustness

## Test plan
- [x] Docker build proof tests both import patterns
- [x] app.* imports resolve to backend.src.* modules
- [x] Maintains compatibility with existing code

🤖 Generated with [Claude Code](https://claude.ai/code)