### PR TITLE
feat(api): enriched /discovery/contenders and accurate holdings with suggestions

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,6 +46,25 @@ for m in mods:
 print("PROOF_OK:", ",".join(ok))
 for m,e in warn:
     print("PROOF_WARN:", m, e)
+
+# Holdings field validation proof (warn-only)
+try:
+    from backend.src.routes.portfolio import build_holding_with_accurate_math
+    sample_holding = {
+        "symbol": "AAPL",
+        "qty": 100,
+        "avg_entry_price": 150.0,
+        "last_price": 160.0
+    }
+    result = build_holding_with_accurate_math(sample_holding, {})
+    required_fields = ["symbol", "qty", "avg_entry_price", "last_price", "market_value", "unrealized_pl", "unrealized_pl_pct", "suggestion"]
+    missing = [f for f in required_fields if f not in result]
+    present = [f for f in required_fields if f in result]
+    print("HOLDINGS_PROOF_OK:", ",".join(present))
+    if missing:
+        print("HOLDINGS_PROOF_WARN: missing fields:", ",".join(missing))
+except Exception as e:
+    print("HOLDINGS_PROOF_WARN:", repr(e))
 PY
 
 EXPOSE 8000

--- a/backend/src/routes/discovery.py
+++ b/backend/src/routes/discovery.py
@@ -20,36 +20,12 @@ def _load_selector():
 
 @router.get("/contenders")
 async def get_contenders() -> List[Dict]:
+    """Return raw contenders data from Redis with all enriched fields"""
     try:
-        # Try Redis first
-        try:
-            redis_client = get_redis_client()
-            cached_data = redis_client.get("amc:discovery:contenders.latest")
-            if cached_data:
-                return json.loads(cached_data)
-        except Exception:
-            pass
-            
-        # Fallback: try to use existing discovery/recommendation services
-        try:
-            from backend.src.services.scoring import ScoringService
-            scoring_service = ScoringService()
-            data = await scoring_service.get_top_recommendations(limit=20)
-            return data or []
-        except ImportError:
-            pass
-            
-        # Fallback: try to get from database directly
-        try:
-            from backend.src.shared.database import get_db_session, Recommendation
-            async with get_db_session() as db:
-                # Get latest recommendations from database
-                results = db.query(Recommendation).order_by(Recommendation.created_at.desc()).limit(20).all()
-                return [{"symbol": r.symbol, "score": r.confidence_score} for r in results]
-        except ImportError:
-            pass
-            
-        # Final fallback: empty list
+        redis_client = get_redis_client()
+        cached_data = redis_client.get("amc:discovery:contenders.latest")
+        if cached_data:
+            return json.loads(cached_data)
         return []
     except Exception:
         return []

--- a/backend/src/routes/portfolio.py
+++ b/backend/src/routes/portfolio.py
@@ -1,28 +1,71 @@
 from fastapi import APIRouter
 from typing import List, Dict
+import json
+from backend.src.shared.redis_client import get_redis_client
 
 router = APIRouter()
 
-def adapt_holding_for_frontend(raw_position: Dict) -> Dict:
-    """Adapt backend position data to frontend expected format"""
-    adapted = {
-        # Frontend expected fields
-        "symbol": raw_position.get("symbol", ""),
-        "quantity": raw_position.get("qty", raw_position.get("quantity", 0)),
-        "current_price": float(raw_position.get("market_value", 0)) / max(float(raw_position.get("qty", 1)), 1) if raw_position.get("market_value") else raw_position.get("current_price", 0),
-        "avg_entry_price": raw_position.get("avg_entry_price", raw_position.get("cost_basis", 0)),
-        "market_value": raw_position.get("market_value", 0),
-        "unrealized_pl": raw_position.get("unrealized_pl", raw_position.get("unrealized_pnl", 0)),
-        "unrealized_plpc": raw_position.get("unrealized_plpc", raw_position.get("unrealized_pnl_pct", 0)),
-        # Keep original data for debugging
-        "_raw": raw_position
+def get_holding_recommendation(symbol: str, unrealized_pl_pct: float, contenders_dict: Dict) -> Dict:
+    """Generate recommendation based on contenders and performance"""
+    if symbol in contenders_dict:
+        score = contenders_dict[symbol].get("score", 0)
+        thesis = contenders_dict[symbol].get("thesis", "")
+        
+        if score >= 0.97:
+            return {"suggestion": "increase", "thesis": thesis}
+        elif score >= 0.94:
+            return {"suggestion": "hold", "thesis": thesis}
+    
+    if symbol not in contenders_dict and unrealized_pl_pct < -0.05:
+        return {"suggestion": "reduce", "thesis": "Position underperforming and not in current contenders"}
+    
+    return {"suggestion": "hold", "thesis": ""}
+
+def build_holding_with_accurate_math(raw_position: Dict, contenders_dict: Dict) -> Dict:
+    """Build holding with accurate math and recommendation"""
+    symbol = raw_position.get("symbol", "")
+    qty = float(raw_position.get("qty", raw_position.get("quantity", 0)))
+    avg_entry_price = float(raw_position.get("avg_entry_price", raw_position.get("cost_basis", 0)))
+    last_price = float(raw_position.get("last_price", raw_position.get("current_price", 0)))
+    
+    # Calculate accurate values
+    market_value = qty * last_price
+    unrealized_pl = (last_price - avg_entry_price) * qty
+    unrealized_pl_pct = (last_price / avg_entry_price - 1) if avg_entry_price > 0 else 0
+    
+    # Get recommendation
+    recommendation = get_holding_recommendation(symbol, unrealized_pl_pct, contenders_dict)
+    
+    return {
+        "symbol": symbol,
+        "qty": qty,
+        "avg_entry_price": avg_entry_price,
+        "last_price": last_price,
+        "market_value": market_value,
+        "unrealized_pl": unrealized_pl,
+        "unrealized_pl_pct": unrealized_pl_pct,
+        "suggestion": recommendation["suggestion"],
+        "thesis": recommendation["thesis"],
+        # Legacy frontend compatibility
+        "quantity": qty,
+        "current_price": last_price
     }
-    return adapted
 
 @router.get("/holdings")
 async def get_holdings() -> Dict:
     try:
         positions = []
+        
+        # Get contenders data from Redis for recommendations
+        contenders_dict = {}
+        try:
+            redis_client = get_redis_client()
+            cached_data = redis_client.get("amc:discovery:contenders.latest")
+            if cached_data:
+                contenders_list = json.loads(cached_data)
+                contenders_dict = {c.get("symbol", ""): c for c in contenders_list if isinstance(c, dict)}
+        except Exception:
+            pass
         
         # Try existing portfolio service
         try:
@@ -32,12 +75,12 @@ async def get_holdings() -> Dict:
             for symbol, value in holdings_dict.items():
                 positions.append({
                     "symbol": symbol,
-                    "quantity": 1,  # Default, may need to be fetched from broker
+                    "qty": 1,  # Default, may need to be fetched from broker
                     "market_value": value,
-                    "current_price": value,
+                    "last_price": value,
                     "avg_entry_price": value,
                     "unrealized_pl": 0,
-                    "unrealized_plpc": 0
+                    "unrealized_pl_pct": 0
                 })
         except ImportError:
             pass
@@ -53,14 +96,21 @@ async def get_holdings() -> Dict:
             except (ImportError, AttributeError):
                 pass
         
-        # Adapt positions for frontend
-        adapted_positions = [adapt_holding_for_frontend(pos) for pos in positions]
+        # Build holdings with accurate math and recommendations
+        enriched_positions = []
+        for pos in positions:
+            try:
+                enriched_pos = build_holding_with_accurate_math(pos, contenders_dict)
+                enriched_positions.append(enriched_pos)
+            except Exception:
+                # Fallback to original position if enrichment fails
+                enriched_positions.append(pos)
         
-        # Return in format expected by frontend: { data: { positions: [...] } }
+        # Return in format expected by frontend
         return {
             "success": True,
             "data": {
-                "positions": adapted_positions
+                "positions": enriched_positions
             }
         }
             


### PR DESCRIPTION
## Summary
- `/discovery/contenders` endpoint now returns raw Redis data with all enriched fields (no shape transformations)
- Holdings endpoint includes accurate financial math: `market_value=qty*last_price`, `unrealized_pl=(last_price-avg_entry_price)*qty`
- Added intelligent per-holding recommendations based on contenders scores:
  - Score ≥ 0.97 → "increase" 
  - Score ≥ 0.94 → "hold"
  - Not in contenders + unrealized_pl_pct < -0.05 → "reduce"
  - Otherwise → "hold"
- Includes thesis from contenders when available
- Added Dockerfile proof for holdings field validation

## Test plan
- [x] Contenders endpoint returns raw Redis data
- [x] Holdings math is accurate with proper P&L calculations  
- [x] Recommendations work based on contenders and performance
- [x] Dockerfile proof validates field structure

🤖 Generated with [Claude Code](https://claude.ai/code)