### PR TITLE
feat(api): expose sector momentum fields in audit & policy

### DIFF
--- a/backend/src/routes/discovery.py
+++ b/backend/src/routes/discovery.py
@@ -67,6 +67,8 @@ async def policy():
       "UTIL_MIN": float(os.getenv("AMC_UTIL_MIN","0.85")),
       "IV_PCTL_MIN": float(os.getenv("AMC_IV_PCTL_MIN","0.80")),
       "PCR_MIN": float(os.getenv("AMC_PCR_MIN","2.0")),
+      "ENABLE_SECTOR": int(os.getenv("AMC_ENABLE_SECTOR","0")),
+      "SECTOR_ETFS": os.getenv("AMC_SECTOR_ETFS","XLF,XLK,XLV,XLE,XLI,XLP,XLY,XLU,XLB,XLRE,XLC"),
       "W": {
         "volume": float(os.getenv("AMC_W_VOLUME","0.25")),
         "short":  float(os.getenv("AMC_W_SHORT","0.20")),
@@ -74,6 +76,7 @@ async def policy():
         "sent":   float(os.getenv("AMC_W_SENT","0.15")),
         "options":float(os.getenv("AMC_W_OPTIONS","0.10")),
         "tech":   float(os.getenv("AMC_W_TECH","0.10")),
+        "sector": float(os.getenv("AMC_W_SECTOR","0.05")),
       },
       "INTRADAY": int(os.getenv("AMC_INTRADAY","0")),
       "LOOKBACK_DAYS": int(os.getenv("LOOKBACK_DAYS","60")),
@@ -91,7 +94,8 @@ async def discovery_audit():
         items = _get_json(r, V2_CONT) or _get_json(r, V1_CONT) or []
         keep = ["symbol", "price", "dollar_vol", "score", "confidence", "rel_vol_30m", 
                 "atr_pct", "float", "si", "borrow", "util", "pcr", "iv_pctl", 
-                "call_oi_up", "sent_score", "trending", "ema_cross", "rsi_zone_ok", "thesis"]
+                "call_oi_up", "sent_score", "trending", "ema_cross", "rsi_zone_ok", "thesis",
+                "sector", "sector_etf", "sector_score", "sector_rs20", "sector_ret5", "sector_ema"]
         result = []
         for item in items:
             if isinstance(item, dict):


### PR DESCRIPTION
## Summary
Enhanced discovery API to expose sector momentum analysis fields for better trading insights and system transparency.

### Audit Endpoints Enhancement
- **`/discovery/audit`**: Now includes sector momentum fields
  - `sector`: Stock's sector classification
  - `sector_etf`: Associated sector ETF symbol  
  - `sector_score`: Sector momentum score
  - `sector_rs20`: 20-day relative strength vs sector
  - `sector_ret5`: 5-day sector return
  - `sector_ema`: Sector EMA trend indicator

### Policy Configuration Expansion
- **`/discovery/policy`**: Added sector-specific configuration
  - `ENABLE_SECTOR`: Toggle for sector momentum analysis (0/1)
  - `SECTOR_ETFS`: Comma-separated list of sector ETF symbols
  - `W.sector`: Weight for sector momentum in scoring (default: 0.05)

### Contenders Pass-Through
- **`/discovery/contenders`**: Sector fields automatically included
- Maintains existing confidence fallback: `score/100` when missing
- No data transformation - complete sector data flows through

## Technical Details
- All sector fields sourced from v2/v1 Redis keys with fallback
- Default sector ETFs: XLF,XLK,XLV,XLE,XLI,XLP,XLY,XLU,XLB,XLRE,XLC
- Sector weight defaults to 5% of total scoring
- Audit endpoints preserve all existing functionality

## Test plan
- [x] Audit endpoints return sector momentum fields
- [x] Policy endpoint exposes sector configuration
- [x] Contenders include sector data without transformation
- [x] Backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)